### PR TITLE
Credit management attributes fix

### DIFF
--- a/lib/buckaroo_client.rb
+++ b/lib/buckaroo_client.rb
@@ -23,9 +23,9 @@ module BuckarooClient
   def self.service(name, attributes = {})
     case name.to_s
     when 'credit_management'
-      Service::CreditManagement.new
+      Service::CreditManagement.new(attributes)
     when 'invoice_specification'
-      Service::InvoiceSpecification.new
+      Service::InvoiceSpecification.new(attributes)
     when 'pay_per_email'
       Service::PayPerEmail.new(attributes)
     else

--- a/spec/buckaroo_client_spec.rb
+++ b/spec/buckaroo_client_spec.rb
@@ -1,0 +1,23 @@
+require 'buckaroo_client'
+
+describe BuckarooClient do
+
+  describe '.service' do
+    let(:init_args) { {} }
+
+    it "creates CreditManagement service with given attributes" do
+      expect(BuckarooClient::Service::CreditManagement).to receive(:new).with(init_args)
+      described_class.service(:credit_management, init_args)
+    end
+
+    it "creates InvoiceSpecification service with given attributes" do
+      expect(BuckarooClient::Service::InvoiceSpecification).to receive(:new).with(init_args)
+      described_class.service(:invoice_specification, init_args)
+    end
+
+    it "creates PayPerEmail service with given attributes" do
+      expect(BuckarooClient::Service::PayPerEmail).to receive(:new).with(init_args)
+      described_class.service(:pay_per_email, init_args)
+    end
+  end
+end


### PR DESCRIPTION
Ensure attributes sent to `BuckarooClient.service` ared being passed on to Service constructors.
